### PR TITLE
add a try-expect block in login_connection

### DIFF
--- a/src/flask_social_blueprint/core.py
+++ b/src/flask_social_blueprint/core.py
@@ -64,9 +64,14 @@ class SocialBlueprint(Blueprint):
         return self.login_connection(connection, profile, provider)
 
     def login_connection(self, connection, profile, provider):
-        user = connection.get_user()
-        assert user, "Connection did not returned a User instance"
-        login_user(user)
+        try:
+            user = connection.get_user()
+            login_user(user)
+        except Exception as ex:
+            logging.warn(ex, exc_info=True)
+            do_flash(_("Could not login: {}").format(ex.message), "warning")
+            return self.login_failed_redirect(profile, provider)
+
         return self.login_redirect(profile, provider)
 
     def login_redirect(self, profile, provider):


### PR DESCRIPTION
防止一个第三方账号被绑定到多个用户上，这样只需要在socialconnection这个model里面的get_user方法上判断并抛出异常即可。
